### PR TITLE
Added possibility to set timezone before reading values

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,5 +16,6 @@ readLongField	KEYWORD2
 readStringField	KEYWORD2
 readStatus	KEYWORD2
 readCreatedAt	KEYWORD2
+setReadTimezone	KEYWORD2
 readRaw	KEYWORD2
 getLastReadStatus	KEYWORD2


### PR DESCRIPTION
The default timezone for the creation date is UTC. 
Because a time convertion is really inconvenient it would be useful that the timezone parameter can be used.
I've added a possibility  to set the timezone before reading values.