### PR TITLE
Remove someone's channel details

### DIFF
--- a/examples/WriteMultipleVoltages/WriteMultipleVoltages.ino
+++ b/examples/WriteMultipleVoltages/WriteMultipleVoltages.ino
@@ -76,8 +76,8 @@
   **** has more information. You need to change this to your channel, and your write API key
   **** IF YOU SHARE YOUR CODE WITH OTHERS, MAKE SURE YOU REMOVE YOUR WRITE API KEY!!
   *****************************************************************************************/
-unsigned long myChannelNumber = 31461;
-const char * myWriteAPIKey = "LD79EOAAWRVYF04Y";
+unsigned long myChannelNumber = <YOUR_CHANNEL_ID>;
+const char * myWriteAPIKey = "<YOUR_WRITE_API_KEY>";
 
 void setup() {
 


### PR DESCRIPTION
That channel is private so there is no use for passers-by. One should use their own channel for the sketch to be worthwhile.
Same with WRITE_API_KEY