### PR TITLE
Fix comparison between unsigned long and signed long

### DIFF
--- a/src/ThingSpeak.h
+++ b/src/ThingSpeak.h
@@ -1556,7 +1556,7 @@ private:
 		// make sure all of the HTTP request is pushed out of the buffer before looking for a response
 		this->client->flush();
 		
-		long timeoutTime = millis() + TIMEOUT_MS_SERVERRESPONSE;
+		unsigned long timeoutTime = millis() + TIMEOUT_MS_SERVERRESPONSE;
 		
 		while(this->client-> available() < 17){
 			delay(2);


### PR DESCRIPTION
Declaring timeoutTime as a long raises two warnings about 
`warning: comparison between signed and unsigned integer expressions`
as `millis()` returns an unsigned long.