### PR TITLE
Fix comparison between signed and unsigned integer warning

### DIFF
--- a/src/ThingSpeak.cpp
+++ b/src/ThingSpeak.cpp
@@ -6,7 +6,7 @@
   
   Copyright 2017, The MathWorks, Inc.
  
-  See the accompaning licence file for licensing information.
+  See the accompanying licence file for licensing information.
 */
 
 #include "ThingSpeak.h"

--- a/src/ThingSpeak.h
+++ b/src/ThingSpeak.h
@@ -1597,7 +1597,7 @@
             // make sure all of the HTTP request is pushed out of the buffer before looking for a response
             this->client->flush();
             
-            long timeoutTime = millis() + TIMEOUT_MS_SERVERRESPONSE;
+            unsigned long timeoutTime = millis() + TIMEOUT_MS_SERVERRESPONSE;
             
             while(this->client-> available() < 17){
                 delay(2);

--- a/src/ThingSpeak.h
+++ b/src/ThingSpeak.h
@@ -9,7 +9,7 @@
   
   Copyright 2020, The MathWorks, Inc.
  
-  See the accompaning licence file for licensing information.
+  See the accompanying licence file for licensing information.
 */
 
 // #define PRINT_DEBUG_MESSAGES
@@ -446,8 +446,8 @@
         
         Notes:
         To record a status message on a write, call setStatus() then call writeFields().
-        Use status to provide additonal details when writing a channel update.
-        Additonally, status can be used by the ThingTweet App to send a message to Twitter.
+        Use status to provide additional details when writing a channel update.
+        Additionally, status can be used by the ThingTweet App to send a message to Twitter.
         */
         int setStatus(String status)
         {


### PR DESCRIPTION
During compilation, warnings are generated because of `comparison between signed and unsigned integer`.  Fixed by declaring the variable as an unsigned long since it is holding `millis()`.